### PR TITLE
Update snippet to include Render Tag

### DIFF
--- a/src/snippets/snippets.json
+++ b/src/snippets/snippets.json
@@ -118,6 +118,16 @@
     "description": "Theme tag: include with parameters",
     "body": ["{% include '${1:snippet}', ${2:variable}: ${3:value} %}"]
   },
+  "Tag render": {
+    "prefix": "render",
+    "description": "Theme tag: render",
+    "body": ["{% render '${1:snippet}' %}"]
+  },
+  "Tag render with parameters": {
+    "prefix": "renderwith",
+    "description": "Theme tag: render with parameters",
+    "body": ["{% render '${1:snippet}', ${2:variable}: ${3:value} %}"]
+  },
   "Tag section": {
     "prefix": "section",
     "description": "Theme tag: section",


### PR DESCRIPTION
See additional information on Render here: https://help.shopify.com/en/themes/liquid/tags/theme-tags#render

The include tag is still available for use but has been deprecated.