### PR TITLE
Update snippets and add form theme tag

### DIFF
--- a/src/snippets/snippets.json
+++ b/src/snippets/snippets.json
@@ -141,7 +141,7 @@
   "Tag form": {
     "prefix": "form",
     "description": "Theme tag: form",
-    "body": ["{% form '${1:product}', ${2:product} %}$3{% endraw %}"]
+    "body": ["{% form '${1:product}', ${2:product} %}$3{% endform %}"]
   },
   "Tag paginate": {
     "prefix": "paginate",

--- a/src/snippets/snippets.json
+++ b/src/snippets/snippets.json
@@ -138,6 +138,11 @@
     "description": "Theme tag: layout none",
     "body": ["{% layout none %}"]
   },
+  "Tag form": {
+    "prefix": "form",
+    "description": "Theme tag: form",
+    "body": ["{% form '${1:product}', ${2:product} %}$3{% endraw %}"]
+  },
   "Tag paginate": {
     "prefix": "paginate",
     "description": "Theme tag: paginate",


### PR DESCRIPTION
I assume you're already aware of this but this is not available in the extension. 

It would also be nice to have all of the form types and tag parameters. :)

More information about the tag is here for reference:
[https://shopify.dev/api/liquid/tags/theme-tags#form](https://shopify.dev/api/liquid/tags/theme-tags#form)